### PR TITLE
Rethink module importing

### DIFF
--- a/lat_source_model/src/lat_source_model/SourceList.py
+++ b/lat_source_model/src/lat_source_model/SourceList.py
@@ -1,13 +1,15 @@
 #utilities imports
-from lat_source_model import (
-    angular_separation,
-    get_ROI_from_event_file,
-    build_region,
-    valid_spatial_input,
-    valid_spectrum_input)
+from lat_source_model.utilities import (
+        angular_separation,
+        get_ROI_from_event_file,
+        build_region,
+        valid_spatial_input,
+        valid_spectrum_input)
 
 #model_components imports
-from lat_source_model import Spectrum,Spatial
+from lat_source_model.model_components import (
+        Spectrum,
+        Spatial)
 
 import os
 

--- a/lat_source_model/src/lat_source_model/model_components.py
+++ b/lat_source_model/src/lat_source_model/model_components.py
@@ -1,6 +1,6 @@
 from xml.dom import minidom
 
-from lat_source_model import parameter_element
+from lat_source_model.utilities import parameter_element
 
 import os
 


### PR DESCRIPTION
Rethinking which modules are directly available in lat_source_model.  Want SourceList imported directly, but keep the others imported with extra '.' notation (e.g., from lat_source_model.utilities import x,y,z)