### PR TITLE
Update make4FGLxml.py

### DIFF
--- a/LATSourceModel/src/LATSourceModel/make4FGLxml.py
+++ b/LATSourceModel/src/LATSourceModel/make4FGLxml.py
@@ -83,7 +83,7 @@ def cli():
                 ,help="Flag to only let the normalizations of parameters be free, default is False.",
                 nargs="?",const=True,choices=['True','False','T','F','t','f','TRUE','FALSE','true','false',1,0])
     
-    parser.add_argument("-e","--extended_directory",type=str,default='',
+    parser.add_argument("-e","--extended_directory",type=str,default=None,
                 help="Path to directory with LAT extended source templates, will default to STs default.")
     
     parser.add_argument("-r","--free_radius",type=float,default=-1.,


### PR DESCRIPTION
Change default value of extended_directory in make4FGLxml.py script to None, to allow for automatically building in the default fermitools path for the extended source template directory